### PR TITLE
Only expose the loopback for services defined in the compose file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Docker compose script to run Postgres and Redis and expose them on the standard 
 To use just install docker and docker-compose and then run:
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 Then Postgres and Redis will be running in the background and available for all your projects.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
   redis:
     image: redis
     # persistent storage
@@ -18,7 +18,7 @@ services:
     volumes:
       - redis_data:/data
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
   pgvector_db:
     image: ankane/pgvector
     # persist data beyond lifetime of container
@@ -28,7 +28,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
 volumes:
   postgres_data:
   redis_data:


### PR DESCRIPTION
Docker compose, by defalut, will expose any service's ports on all local and remote interfaces. Not only that, it attempts to punch a hole in the firewall to allow all remote machines access to these, even if you've already set up a rule limiting what remote machines can reach on your system.

This is kind of a fringe issue on a dev system; it'll only ever be a problem if, say, you're working on an untrusted network somewhere.

But if someone decides to use this on a VPS, it's hazardous. Especially for redis.

I blogged about the behavior in more detail here:
https://geoff.tuxpup.com/posts/psa_docker_edits_firewall_rules/

This patch only exposes the services on `127.0.0.1` to prevent docker from exposing things that shouldn't be on the internet.